### PR TITLE
Changed 'string' to 'text'

### DIFF
--- a/entities/student.entity.ts
+++ b/entities/student.entity.ts
@@ -22,7 +22,7 @@ export class Student {
   @Column("text", { array: true, nullable: true })
   skills?: ESkills[];
 
-  @Column("string", { default: 0 })
+  @Column("text", { default: 0 })
   groupId: string;
 
   // @Column({ name: "created_at" })


### PR DESCRIPTION
I think this may have been a typo in its implementation. When running before it was throwing an error saying that data type ... string is not supported by a postgres database. I then saw implementation of other fields and how they use 'text' so I suspect it may have just been a typo